### PR TITLE
Make navigation align with content

### DIFF
--- a/index.css
+++ b/index.css
@@ -217,6 +217,11 @@ nav {
   width: 100%;
 }
 
+nav ul.nav {
+  max-width: 856px;
+  margin: 1em auto;
+}
+
 nav .nav li {
   display: inline-block;
 }


### PR DESCRIPTION
Currently, the navigation at the bottom of the page doesn't line up with the rest of the content, and is just aligned to the left. This change will make the navigation align with the content.

Current:
![screen shot 2016-03-23 at 11 35 47 pm](https://cloud.githubusercontent.com/assets/403961/14008559/285378ce-f150-11e5-9a79-716592b9f9c5.png)

Proposed Change:
![screen shot 2016-03-23 at 11 35 53 pm](https://cloud.githubusercontent.com/assets/403961/14008564/3056d5de-f150-11e5-87e2-56b193f3aca4.png)

---

**Why?**

I know it sounds silly, but this means there is less cognitive overhead when looking for the navigation, as it just requires looking down from the content, and not having to move your eyes over at all.

Also, and I know this is entirely a personal preference (and really the majority of why I looked into the tweak at all), I think it looks cleaner and more consistent.
